### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: SonarQube
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/FileJunkie/KMyMoney.Net/security/code-scanning/1](https://github.com/FileJunkie/KMyMoney.Net/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. In this case, since the workflow only checks out code and runs analysis, the minimal permission required is likely `contents: read`. The best way to fix this is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` line and before `on:`), so it applies to all jobs. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
